### PR TITLE
Fixed logic error in Extend your API page

### DIFF
--- a/pages/en/lb2/Extend-your-API.md
+++ b/pages/en/lb2/Extend-your-API.md
@@ -55,7 +55,7 @@ Follow these steps:
         var CLOSE_HOUR = 20;
         console.log('Current hour is %d', currentHour);
         var response;
-        if (currentHour > OPEN_HOUR && currentHour < CLOSE_HOUR) {
+        if (currentHour >= OPEN_HOUR && currentHour < CLOSE_HOUR) {
           response = 'We are open for business.';
         } else {
           response = 'Sorry, we are closed. Open daily from 6am to 8pm.';

--- a/pages/en/lb3/Extend-your-API.md
+++ b/pages/en/lb3/Extend-your-API.md
@@ -55,7 +55,7 @@ Follow these steps:
         var CLOSE_HOUR = 20;
         console.log('Current hour is %d', currentHour);
         var response;
-        if (currentHour > OPEN_HOUR && currentHour < CLOSE_HOUR) {
+        if (currentHour >= OPEN_HOUR && currentHour < CLOSE_HOUR) {
           response = 'We are open for business.';
         } else {
           response = 'Sorry, we are closed. Open daily from 6am to 8pm.';

--- a/pages/ru/lb2/Extend-your-API.md
+++ b/pages/ru/lb2/Extend-your-API.md
@@ -50,7 +50,7 @@ $ npm install
         var CLOSE_HOUR = 20;
         console.log('Current hour is ' + currentHour);
         var response;
-        if (currentHour > OPEN_HOUR && currentHour < CLOSE_HOUR) {
+        if (currentHour >= OPEN_HOUR && currentHour < CLOSE_HOUR) {
           response = 'We are open for business.';
         } else {
           response = 'Sorry, we are closed. Open daily from 6am to 8pm.';


### PR DESCRIPTION
We need to use `currentHour >= OPEN_HOUR` so that it says the shop is open when the `currentHour` is between 06:00 and 07:00.